### PR TITLE
[WW-4952] Upgrades parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -319,9 +319,9 @@
             </roles>
         </developer>
         <developer>
-            <name>Aleksandr Mashchenko</name>
-            <id>amashchenko</id>
-            <email>amashchenko at apache.org</email>
+            <name>Yasser Zamani</name>
+            <id>yasserzamani</id>
+            <email>yasserzamani at apache.org</email>
             <roles>
                 <role>PMC Member</role>
             </roles>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
-        <version>18</version>
+        <version>21</version>
     </parent>
     <groupId>org.apache.struts</groupId>
     <artifactId>struts-master</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -322,14 +322,6 @@
                 <role>PMC Member</role>
             </roles>
         </developer>
-        <developer>
-            <name>Yasser Zamani</name>
-            <id>yasserzamani</id>
-            <email>yasserzamani at apache.org</email>
-            <roles>
-                <role>Committer</role>
-            </roles>
-        </developer>
     </developers>
     <distributionManagement>
         <site>

--- a/pom.xml
+++ b/pom.xml
@@ -307,9 +307,9 @@
             </roles>
         </developer>
         <developer>
-            <name>Yasser Zamani</name>
-            <id>yasserzamani</id>
-            <email>yasserzamani at apache.org</email>
+            <name>Aleksandr Mashchenko</name>
+            <id>amashchenko</id>
+            <email>amashchenko at apache.org</email>
             <roles>
                 <role>PMC Member</role>
             </roles>
@@ -318,6 +318,14 @@
             <name>Stefaan Dutry</name>
             <id>sdutry</id>
             <email>sdutry at apache.org</email>
+            <roles>
+                <role>PMC Member</role>
+            </roles>
+        </developer>
+        <developer>
+            <name>Yasser Zamani</name>
+            <id>yasserzamani</id>
+            <email>yasserzamani at apache.org</email>
             <roles>
                 <role>PMC Member</role>
             </roles>

--- a/pom.xml
+++ b/pom.xml
@@ -12,9 +12,9 @@
     <name>Apache Struts</name>
 
     <scm>
-        <connection>scm:git:git://git.apache.org/struts-master.git</connection>
-        <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/struts-master.git</developerConnection>
-        <url>http://git.apache.org/struts-master.git</url>
+        <connection>scm:git:https://gitbox.apache.org/repos/asf/struts-master.git</connection>
+        <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/struts-master.git</developerConnection>
+        <url>https://github.com/apache/struts-master/</url>
         <tag>HEAD</tag>
     </scm>
 
@@ -34,38 +34,26 @@
             <subscribe>user-subscribe@struts.apache.org</subscribe>
             <unsubscribe>user-unsubscribe@struts.apache.org</unsubscribe>
             <post>user@struts.apache.org</post>
-            <archive>http://mail-archives.apache.org/mod_mbox/struts-user/</archive>
-            <otherArchives>
-                <otherArchive>http://struts.apache.org/mail.html#Archives</otherArchive>
-            </otherArchives>
+            <archive>https://lists.apache.org/list.html?user@struts.apache.org</archive>
         </mailingList>
         <mailingList>
             <name>Struts Developer List</name>
             <subscribe>dev-subscribe@struts.apache.org</subscribe>
             <unsubscribe>dev-unsubscribe@struts.apache.org</unsubscribe>
             <post>dev@struts.apache.org</post>
-            <archive>http://mail-archives.apache.org/mod_mbox/struts-dev/</archive>
-            <otherArchives>
-                <otherArchive>http://struts.apache.org/dev/dev-mail.html#Archives</otherArchive>
-            </otherArchives>
+            <archive>https://lists.apache.org/list.html?dev@struts.apache.org</archive>
         </mailingList>
         <mailingList>
             <name>Struts Commits List</name>
             <subscribe>commits-subscribe@struts.apache.org</subscribe>
             <unsubscribe>commits-unsubscribe@struts.apache.org</unsubscribe>
-            <archive>http://mail-archives.apache.org/mod_mbox/struts-commits/</archive>
-            <otherArchives>
-                <otherArchive>http://struts.apache.org/dev/dev-mail.html#Archives</otherArchive>
-            </otherArchives>
+            <archive>https://lists.apache.org/list.html?commits@struts.apache.org</archive>
         </mailingList>
         <mailingList>
             <name>Struts Issues List</name>
             <subscribe>issues-subscribe@struts.apache.org</subscribe>
             <unsubscribe>issues-unsubscribe@struts.apache.org</unsubscribe>
-            <archive>http://mail-archives.apache.org/mod_mbox/struts-issues/</archive>
-            <otherArchives>
-                <otherArchive>http://struts.apache.org/dev/dev-mail.html#Archives</otherArchive>
-            </otherArchives>
+            <archive>https://lists.apache.org/list.html?issues@struts.apache.org</archive>
         </mailingList>
     </mailingLists>
 


### PR DESCRIPTION
This PR upgrades `struts-master` to use the latest version of `apache-master` plus it cleans up few urls.

Fixes [WW-4952](https://issues.apache.org/jira/browse/WW-4952)